### PR TITLE
fix: input reference for input mask component

### DIFF
--- a/src/components/input-mask.tsx
+++ b/src/components/input-mask.tsx
@@ -27,14 +27,7 @@ const CustonInput = React.forwardRef<HTMLInputElement, InputProps>(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
-        // TODO: fix this ref issue
-        // (property) React.ClassAttributes<ReactInputMask>.ref?: React.LegacyRef<InputMask> | undefined
-        // Allows getting a ref to the component instance. Once the component unmounts, React will set ref.current to null (or call the ref with null if you passed a callback ref).
-        // @see — https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        ref={ref}
+        inputRef={ref}
         {...props}
       />
     );


### PR DESCRIPTION
Input reference for compability between shadcn-ui and react-input-mask.